### PR TITLE
add log on db migration

### DIFF
--- a/api/lib/resource/database.js
+++ b/api/lib/resource/database.js
@@ -112,9 +112,14 @@ class Database {
 		for (let i = versionDoc.version; i < migrations.length; ++i) {
 			winston.log('info', '[Database] Updating from version ' + versionDoc.version);
 
-			await migrations[i]();
-			versionDoc.version += 1;
-			await this.insert(versionDoc);
+			try {
+				await migrations[i]();
+				versionDoc.version += 1;
+				await this.insert(versionDoc);
+			} catch (e) {
+				winston.log('error', '[Database] Migration failed: ' + e.message);
+        break;
+      }
 		}
 
 		winston.log('info', '[Database] No more migrations. Current version is ' + versionDoc.version);
@@ -135,7 +140,7 @@ class Database {
 				return lock;
 			}
 			catch (e) {
-				winston.log('info', '[Database] Failed to acquire migration lock :');
+				winston.log('info', '[Database] Failed to acquire migration lock :' + e.message);
 
 				await delay();
 				return getLockRec();

--- a/api/lib/resource/migrations/migration-10.js
+++ b/api/lib/resource/migrations/migration-10.js
@@ -21,8 +21,10 @@ export default async () => {
 
         emit(doc._id, progress / count);
       }
-    }.toString(),
+    }
+      .toString()
+      .replace(/\n/g, "")
+      .replace(/\s+/g, " "),
   };
-
   await database.insert(ddoc);
 };


### PR DESCRIPTION
This PR:
* Changes the stringified version of the `inputs_with_progress` view to remove tabs and newlines, so it's easier to read on cli or on couchdb
* Adds a try catch block on migrations. If a migration fails, the error will be logged and the version won't be updated.